### PR TITLE
optimize rtmp-forwarder ffmpeg stream command

### DIFF
--- a/internal/rtmp/streamer.go
+++ b/internal/rtmp/streamer.go
@@ -19,7 +19,7 @@ func NewStreamer(quit chan struct{}) *Streamer {
 
 func (s *Streamer) StartFFmpeg(ctx context.Context, streamURL string) error {
 	// Create a ffmpeg process that consumes MKV via stdin, and broadcasts out to Stream URL
-	ffmpeg := exec.CommandContext(ctx, "ffmpeg", "-protocol_whitelist", "file,udp,rtp", "-i", "rtp-forwarder.sdp", "-c:v", "copy", "-c:a", "aac", "-f", "flv", "-flvflags", "no_duration_filesize", "-c:v", "libx264", streamURL) //nolint
+	ffmpeg := exec.CommandContext(ctx, "ffmpeg", "-protocol_whitelist", "file,udp,rtp", "-i", "rtp-forwarder.sdp", "-c:v", "libx264", "-preset", "veryfast", "-b:v", "3000k", "-maxrate", "3000k", "-bufsize", "6000k", "-pix_fmt", "yuv420p", "-g", "50", "-c:a", "aac", "-b:a", "160k", "-ac", "2", "-ar", "44100", "-f", "flv", streamURL) //nolint
 	if _, err := ffmpeg.StdinPipe(); err != nil {
 		return fmt.Errorf("piping ffmpeg: %w", err)
 	}


### PR DESCRIPTION
After implementing this modification, the stream no longer experienced any stuttering